### PR TITLE
WIP: Added CHANGELOG.md file. Adjusted buildscript to read it directly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+
+## [0.1.3] - 2020-05-11
+### Fixed
+- Crashes
+
+### Added
+- Basic Function support and Improved language grammar (Function Bodys are not yet working but WIP)
+
+## [0.1.2] - 2020-05-08
+### Fixed
+- Make compatible with newer IDE versions
+
+## [0.1.1] - 2020-03-15
+### Fixed
+- Fix "New File" action
+
+## [0.1.0] 
+### Added
+- Initial Release
+- Added most basic features

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,10 +2,11 @@ import org.jetbrains.grammarkit.tasks.GenerateLexer
 import org.jetbrains.grammarkit.tasks.GenerateParser
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import com.github.rjeschke.txtmark.Processor
+import java.util.Scanner
 
 plugins {
     idea
-    id("org.jetbrains.intellij") version "0.4.21"
+    id("org.jetbrains.intellij") version "0.4.20"
     id("org.jetbrains.grammarkit") version "2020.1.4"
     kotlin("jvm") version "1.3.72"
     java
@@ -43,18 +44,33 @@ configure<JavaPluginConvention> {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+
 buildscript {
-    repositories {
-        mavenCentral()
-    }
     dependencies {
         classpath("es.nitaur.markdown:txtmark:0.16")
     }
 }
 
+val pluginDescMkdown = """
+A simple plugin for developing AutoHotKey scripts. The following features are available:
+
+- Syntax highlighting
+- Run configurations
+- More to come in the future...
+
+*Note: This plugin is under development and does not have a stable release yet*
+""".trimIndent()
+
 tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {
-    val htmlChangeNotes = Processor.process(rootProject.file("CHANGELOG.md").readText())
-    changeNotes(htmlChangeNotes)
+    val latestChangesRegex = """(## \[\d+\.\d+\.\d+\][\w\W]*?)## \["""
+    val latestChangesMkdown = Scanner(rootProject.file("CHANGELOG.md")).findWithinHorizon(latestChangesRegex, 0)
+    var latestChangeNotes = latestChangesRegex.toRegex().find(latestChangesMkdown)!!.groups[1]!!.value
+    latestChangeNotes += "Please see [CHANGELOG.md](https://github.com/Nordgedanken/auto_hot_key_jetbrains_plugin/blob/master/CHANGELOG.md) for a full list of changes."
+    changeNotes(Processor.process(latestChangeNotes))
+
+    pluginDescription(Processor.process(pluginDescMkdown))
+
+    setVersion(version)
 }
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,11 @@
 import org.jetbrains.grammarkit.tasks.GenerateLexer
 import org.jetbrains.grammarkit.tasks.GenerateParser
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import com.github.rjeschke.txtmark.Processor
 
 plugins {
     idea
-    id("org.jetbrains.intellij") version "0.4.20"
+    id("org.jetbrains.intellij") version "0.4.21"
     id("org.jetbrains.grammarkit") version "2020.1.4"
     kotlin("jvm") version "1.3.72"
     java
@@ -29,7 +30,6 @@ tasks.publishPlugin {
     if (intellijPublishToken != null) {
         token(intellijPublishToken)
     }
-
 }
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
@@ -43,33 +43,18 @@ configure<JavaPluginConvention> {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath("es.nitaur.markdown:txtmark:0.16")
+    }
+}
+
 tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {
-    changeNotes("""
-        <h2>0.1.3</h2>
-        <h3>Fixed</h3>
-        <ul>
-            <li>Crashes</li>
-        </ul>
-        <h3>Added</h3>
-        <ul>
-            <li>Basic Function support and Improved language grammar (Function Bodys are not yet working but WIP)</li>
-        </ul>
-        <h2>0.1.2</h2>
-        <h3>Fixed</h3>
-        <ul>
-            <li>Make compatible with newer IDE versions</li>
-        </ul>
-        <h2>0.1.1</h2>
-        <h3>Fixed</h3>
-        <ul>
-            <li>Fix "New File" action</li>
-        </ul>
-        <h2>0.1.0</h2>
-        <h3>Added</h3>
-        <ul>
-            <li>Initial Release</li>
-            <li>Added most basic features</li>
-        </ul>""")
+    val htmlChangeNotes = Processor.process(rootProject.file("CHANGELOG.md").readText())
+    changeNotes(htmlChangeNotes)
 }
 
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,14 +3,10 @@
     <name>AutoHotkey Language</name>
     <vendor email="info@nordgedanken.de" url="https://github.com/Nordgedanken/">Nordgedanken</vendor>
 
-    <description>A simple plugin to bring AutoHotKey syntax highlighting into Jetbrains IDEs!</description>
-
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.java</depends>
-
-    <version>0.1.3</version>
 
     <extensions defaultExtensionNs="com.intellij">
         <fileType name="AHK script" implementationClass="de.nordgedanken.auto_hotkey.AHKFileType"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,42 +3,12 @@
     <name>AutoHotkey Language</name>
     <vendor email="info@nordgedanken.de" url="https://github.com/Nordgedanken/">Nordgedanken</vendor>
 
-    <description><![CDATA[
-    A simple Plugin to bring the AutoHotKey Syntax highlighting into Jetbrains!
-    ]]></description>
+    <description>A simple plugin to bring AutoHotKey syntax highlighting into Jetbrains IDEs!</description>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
          on how to target different products -->
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.java</depends>
-
-    <change-notes><![CDATA[
-        <h2>0.1.3</h2>
-        <h3>Fixed</h3>
-        <ul>
-            <li>Crashes</li>
-        </ul>
-        <h3>Added</h3>
-        <ul>
-            <li>Basic Function support and Improved language grammar (Function Bodys are not yet working but WIP)</li>
-        </ul>
-        <h2>0.1.2</h2>
-        <h3>Fixed</h3>
-        <ul>
-            <li>Make compatible with newer IDE versions</li>
-        </ul>
-        <h2>0.1.1</h2>
-        <h3>Fixed</h3>
-        <ul>
-            <li>Fix "New File" action</li>
-        </ul>
-        <h2>0.1.0</h2>
-        <h3>Added</h3>
-        <ul>
-            <li>Initial Release</li>
-            <li>Added most basic features</li>
-        </ul>
-    ]]></change-notes>
 
     <version>0.1.3</version>
 


### PR DESCRIPTION
Hi mtrnord,

I'm still learning my way around the repository, but I saw immediately that the changelog is being duplicated, which is unnecessary. This PR will allow us to just make changes to CHANGELOG.md file, and the build script will automatically read the changelog to update the change notes in the plugin xml.

**Please don't merge the PR yet. I want to make sure you are okay with the changes, and then I will add some additional code to this PR so that only the changelog stuff for the most recent version is added to the change notes**