### PR TITLE
Feature/30 fix compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New page added to Settings dialog for AutoHotkey settings
+- Sdk-management toolbar (eg add/edit/remove sdk) added to AutoHotkey settings
+
+### Changed
+- Settings button next to "Script Runner" field in run config UI now points to new AutoHotkey page in Settings
+- Updated compatibility to work with IntelliJ 2020.2
+
+### Fixed
+- Removed/commented classes that prevented the plugin from working in non-IDEA IDEs 
 
 ## [0.3.0] - 2020-07-23
 ### Added
@@ -14,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Moved run config validity verifications from runtime to within the "Edit Configurations" dialog
+
+### Removed
+- Removed dependency on Java plugin
 
 ## [0.2.0] - 2020-06-07
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,6 @@ tasks.publishPlugin {
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
     version = "2019.3"
-    setPlugins("java")
 }
 
 configure<JavaPluginConvention> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml
 
     pluginDescription(Processor.process(pluginDescMkdown))
     version("## \\[(\\d+\\.\\d+\\.\\d+)\\]".toRegex().find(latestChangesMkdown)!!.groups[1]!!.value)
-    untilBuild("201.*")
+    untilBuild("202.*")
 }
 
 

--- a/src/main/java/de/nordgedanken/auto_hotkey/AHKReferenceContributor.kt
+++ b/src/main/java/de/nordgedanken/auto_hotkey/AHKReferenceContributor.kt
@@ -2,19 +2,16 @@ package de.nordgedanken.auto_hotkey
 
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.util.Condition
-import com.intellij.patterns.PlatformPatterns
-import com.intellij.psi.*
-import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReference
+import com.intellij.psi.PsiFileSystemItem
+import com.intellij.psi.PsiReferenceContributor
+import com.intellij.psi.PsiReferenceRegistrar
 import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReferenceSet
-import com.intellij.util.ProcessingContext
 import de.nordgedanken.auto_hotkey.psi.AHKLitExpr
-import de.nordgedanken.auto_hotkey.psi.AHKLiteralKind
-import de.nordgedanken.auto_hotkey.psi.kind
 
 class AHKReferenceContributor : PsiReferenceContributor() {
     private val log: Logger = Logger.getInstance("#de.nordgedanken.auto_hotkey.AHKReferenceContributor")
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
-        registrar.registerReferenceProvider(PlatformPatterns.psiElement(PsiLiteralExpression::class.java),
+       /* registrar.registerReferenceProvider(PlatformPatterns.psiElement(PsiLiteralExpression::class.java),
                 object : PsiReferenceProvider() {
                     override fun getReferencesByElement(element: PsiElement,
                                                         context: ProcessingContext): Array<out FileReference> {
@@ -26,7 +23,7 @@ class AHKReferenceContributor : PsiReferenceContributor() {
                         return AHKLiteralFileReferenceSet(stringLiteral.value
                                 ?: "", element, startOffset, fs.isCaseSensitive).allReferences
                     }
-                })
+                })*/
     }
 }
 

--- a/src/main/java/de/nordgedanken/auto_hotkey/run_configurations/ui/AhkRunConfigSettingsEditor.kt
+++ b/src/main/java/de/nordgedanken/auto_hotkey/run_configurations/ui/AhkRunConfigSettingsEditor.kt
@@ -4,7 +4,6 @@ import com.intellij.icons.AllIcons
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ui.configuration.IdeaProjectSettingsService
 import com.intellij.openapi.ui.FixedSizeButton
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.ui.components.fields.ExpandableTextField
@@ -71,7 +70,7 @@ class AhkRunConfigSettingsEditor(private val project: Project) : SettingsEditor<
      * sees that the selected sdk is the same and does not fire any update events)
      */
     private fun openProjStrucDialogAndThenTriggerEditorUpdate() {
-        IdeaProjectSettingsService.getInstance(project).openProjectSettings()
+//        IdeaProjectSettingsService.getInstance(project).openProjectSettings()
         ahkSdkComboBox.updateSdkList()
         //this part is just to trigger the settings editor event listeners to update the error message
         val tmp = ahkSdkComboBox.selectedItem

--- a/src/main/java/de/nordgedanken/auto_hotkey/run_configurations/ui/AhkRunConfigSettingsEditor.kt
+++ b/src/main/java/de/nordgedanken/auto_hotkey/run_configurations/ui/AhkRunConfigSettingsEditor.kt
@@ -3,6 +3,7 @@ package de.nordgedanken.auto_hotkey.run_configurations.ui
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.options.SettingsEditor
+import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.FixedSizeButton
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
@@ -12,6 +13,7 @@ import com.intellij.ui.layout.panel
 import de.nordgedanken.auto_hotkey.AhkConstants
 import de.nordgedanken.auto_hotkey.localization.AhkBundle
 import de.nordgedanken.auto_hotkey.run_configurations.core.AhkRunConfig
+import de.nordgedanken.auto_hotkey.settings.AhkProjectConfigurable
 import javax.swing.JComponent
 
 /**
@@ -30,9 +32,9 @@ class AhkRunConfigSettingsEditor(private val project: Project) : SettingsEditor<
     private val argumentsTextField: ExpandableTextField = ExpandableTextField()
     private val ahkSdkComboBox: AhkSdkComboBox = AhkSdkComboBox(project)
     private val openProjectSettingsButton: FixedSizeButton = FixedSizeButton().apply {
-        icon = AllIcons.General.ProjectStructure
+        icon = AllIcons.General.GearPlain
         toolTipText = AhkBundle.msg("runconfig.configtab.scriptrunner.projectsettingsbutton.tooltip")
-        addActionListener { openProjStrucDialogAndThenTriggerEditorUpdate() }
+        addActionListener { openProjSettingsAndThenTriggerEditorUpdate() }
     }
 
     override fun resetEditorFrom(s: AhkRunConfig) {
@@ -69,8 +71,8 @@ class AhkRunConfigSettingsEditor(private val project: Project) : SettingsEditor<
      * in the dropdown so that the editor state is updated (otherwise the editor
      * sees that the selected sdk is the same and does not fire any update events)
      */
-    private fun openProjStrucDialogAndThenTriggerEditorUpdate() {
-//        IdeaProjectSettingsService.getInstance(project).openProjectSettings()
+    private fun openProjSettingsAndThenTriggerEditorUpdate() {
+        ShowSettingsUtil.getInstance().showSettingsDialog(project, AhkProjectConfigurable::class.java)
         ahkSdkComboBox.updateSdkList()
         //this part is just to trigger the settings editor event listeners to update the error message
         val tmp = ahkSdkComboBox.selectedItem

--- a/src/main/java/de/nordgedanken/auto_hotkey/run_configurations/ui/AhkSdkComboBox.kt
+++ b/src/main/java/de/nordgedanken/auto_hotkey/run_configurations/ui/AhkSdkComboBox.kt
@@ -2,12 +2,12 @@ package de.nordgedanken.auto_hotkey.run_configurations.ui
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.Sdk
-import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.CollectionComboBoxModel
 import de.nordgedanken.auto_hotkey.sdk.AhkSdkType
 import de.nordgedanken.auto_hotkey.sdk.getAhkSdkByName
 import de.nordgedanken.auto_hotkey.sdk.getAhkSdks
+import de.nordgedanken.auto_hotkey.sdk.sdk
 
 class AhkSdkComboBox(private val currentProject: Project) : ComboBox<Any?>() {
     private var projectSdk: Sdk? = null
@@ -25,7 +25,7 @@ class AhkSdkComboBox(private val currentProject: Project) : ComboBox<Any?>() {
      * because the settingseditor will change the selectedItem a few moments after construction via setSelectedSdk...()
      */
     fun updateSdkList() {
-        projectSdk = ProjectRootManager.getInstance(currentProject).projectSdk
+        projectSdk = currentProject.sdk
         (renderer as AhkSdkListCellRenderer).projectSdk = projectSdk //needed since it starts out null
         model = CollectionComboBoxModel(getAhkSdks().toList(), getAhkSdkByNameIfArgIsString(selectedItem))
     }

--- a/src/main/java/de/nordgedanken/auto_hotkey/run_configurations/ui/AhkSdkListCellRenderer.kt
+++ b/src/main/java/de/nordgedanken/auto_hotkey/run_configurations/ui/AhkSdkListCellRenderer.kt
@@ -9,7 +9,7 @@ import de.nordgedanken.auto_hotkey.localization.AhkBundle
 import de.nordgedanken.auto_hotkey.sdk.AhkSdkType
 import javax.swing.JList
 
-class AhkSdkListCellRenderer constructor(internal var projectSdk: Sdk?) : ColoredListCellRenderer<Any>() {
+class AhkSdkListCellRenderer constructor(var projectSdk: Sdk?) : ColoredListCellRenderer<Any>() {
     /**
      * Render AhkSdks in the combobox list according to setupComboBoxEntry, or some form of error string for the entry otherwise
      */

--- a/src/main/java/de/nordgedanken/auto_hotkey/sdk/AhkSdkType.kt
+++ b/src/main/java/de/nordgedanken/auto_hotkey/sdk/AhkSdkType.kt
@@ -1,7 +1,9 @@
 package de.nordgedanken.auto_hotkey.sdk
 
 import com.google.common.flogger.FluentLogger
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.projectRoots.*
+import com.intellij.openapi.roots.ProjectRootManager
 import com.jetbrains.rd.util.use
 import de.nordgedanken.auto_hotkey.AHKIcons
 import de.nordgedanken.auto_hotkey.AhkConstants
@@ -18,10 +20,14 @@ import javax.swing.Icon
 /**
  * Controls how the AutoHotkey Sdk type will look and work in the IDE. Registered in plugin.xml
  */
-class AhkSdkType : SdkType("AutoHotkeySDK") {
+object AhkSdkType : SdkType("AutoHotkeySDK") {
+    private val logger = FluentLogger.forEnclosingClass()
+
+    fun getInstance() = findInstance(this::class.java)
+
     override fun getIcon(): Icon = AHKIcons.EXE
 
-    override fun suggestHomePath() = "C:\\Program Files\\AutoHotkey"
+    override fun suggestHomePath() = """C:\Program Files\AutoHotkey"""
 
     /**
      * Verified that there is an "AutoHotkey.exe" in the directory the user selects
@@ -74,8 +80,7 @@ class AhkSdkType : SdkType("AutoHotkeySDK") {
     }
 
     override fun setupSdkPaths(sdk: Sdk, sdkModel: SdkModel) = true
-
-    companion object {
-        private val logger = FluentLogger.forEnclosingClass()
-    }
 }
+
+//convenience method to get the projectSdk
+val Project.sdk: Sdk? get() = ProjectRootManager.getInstance(this).projectSdk

--- a/src/main/java/de/nordgedanken/auto_hotkey/sdk/AhkSdkUtil.kt
+++ b/src/main/java/de/nordgedanken/auto_hotkey/sdk/AhkSdkUtil.kt
@@ -2,7 +2,6 @@ package de.nordgedanken.auto_hotkey.sdk
 
 import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
-import com.intellij.openapi.projectRoots.SdkType
 
 /**
  * These methods are auto-written to a static class by Kotlin compiler.
@@ -14,8 +13,6 @@ import com.intellij.openapi.projectRoots.SdkType
  */
 fun getAhkSdkByName(sdkName: String): Sdk? = getAhkSdks().find { it.name == sdkName }
 
-fun getAhkSdks(): MutableList<Sdk> {
-    return ProjectJdkTable.getInstance().getSdksOfType(
-            ProjectJdkTable.getInstance().getSdkTypeByName(
-                    SdkType.findInstance(AhkSdkType::class.java).name)).toMutableList()
+fun getAhkSdks(): List<Sdk> {
+    return ProjectJdkTable.getInstance().getSdksOfType(AhkSdkType.getInstance()).toList()
 }

--- a/src/main/java/de/nordgedanken/auto_hotkey/settings/AhkProjectConfigurable.kt
+++ b/src/main/java/de/nordgedanken/auto_hotkey/settings/AhkProjectConfigurable.kt
@@ -1,0 +1,29 @@
+package de.nordgedanken.auto_hotkey.settings
+
+import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.project.Project
+import com.intellij.ui.layout.panel
+import de.nordgedanken.auto_hotkey.AhkConstants
+import de.nordgedanken.auto_hotkey.settings.ui.AhkProjectSettingsPanel
+
+/**
+ * This project configurable is the backend support for the AutoHotkey settings that are present when you click on
+ * "AutoHotkey" in the Settings pane, which is under "Language & Frameworks". Handles saving the settings, calling the
+ * UI renderer, etc.
+ */
+class AhkProjectConfigurable(
+        project: Project
+) : Configurable {
+    private val ahkProjectSettingsPanel = AhkProjectSettingsPanel(project)
+
+    override fun isModified(): Boolean = false
+
+    override fun getDisplayName() = AhkConstants.LANGUAGE_NAME
+
+    override fun apply() {
+    }
+
+    override fun createComponent() = panel {
+        ahkProjectSettingsPanel.attachTo(this)
+    }
+}

--- a/src/main/java/de/nordgedanken/auto_hotkey/settings/ui/AhkProjectSettingsPanel.kt
+++ b/src/main/java/de/nordgedanken/auto_hotkey/settings/ui/AhkProjectSettingsPanel.kt
@@ -1,0 +1,25 @@
+package de.nordgedanken.auto_hotkey.settings.ui
+
+import com.intellij.openapi.project.Project
+import com.intellij.ui.layout.LayoutBuilder
+import de.nordgedanken.auto_hotkey.localization.AhkBundle
+import javax.swing.JPanel
+
+/**
+ * Contains the UI rendering logic of all the settings that are supported by AhkProjectConfigurable
+ */
+class AhkProjectSettingsPanel(project: Project) {
+    private val ahkSdkToolbar: JPanel = AhkSdkToolbarPanel(project).panel
+
+    fun attachTo(layoutBuilder: LayoutBuilder) = with(layoutBuilder) {
+        row {
+            cell(true) {
+                label(AhkBundle.msg("settings.ahkrunners.general.label"))
+                ahkSdkToolbar(pushX, growX)
+            }
+        }
+        row {
+            label(AhkBundle.msg("settings.ahkrunners.general.info"))
+        }
+    }
+}

--- a/src/main/java/de/nordgedanken/auto_hotkey/settings/ui/AhkProjectSettingsPanel.kt
+++ b/src/main/java/de/nordgedanken/auto_hotkey/settings/ui/AhkProjectSettingsPanel.kt
@@ -14,12 +14,12 @@ class AhkProjectSettingsPanel(project: Project) {
     fun attachTo(layoutBuilder: LayoutBuilder) = with(layoutBuilder) {
         row {
             cell(true) {
-                label(AhkBundle.msg("settings.ahkrunners.general.label"))
+                label(AhkBundle.msg("settings.autohotkey.ahkrunners.general.label"))
                 ahkSdkToolbar(pushX, growX)
             }
         }
         row {
-            label(AhkBundle.msg("settings.ahkrunners.general.info"))
+            label(AhkBundle.msg("settings.autohotkey.ahkrunners.general.info"))
         }
     }
 }

--- a/src/main/java/de/nordgedanken/auto_hotkey/settings/ui/AhkSdkToolbarPanel.kt
+++ b/src/main/java/de/nordgedanken/auto_hotkey/settings/ui/AhkSdkToolbarPanel.kt
@@ -1,0 +1,68 @@
+package de.nordgedanken.auto_hotkey.settings.ui
+
+import com.intellij.openapi.fileChooser.FileChooser
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.Sdk
+import com.intellij.openapi.projectRoots.impl.SdkConfigurationUtil
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.ui.CollectionListModel
+import com.intellij.ui.ToolbarDecorator
+import com.intellij.ui.components.JBList
+import de.nordgedanken.auto_hotkey.localization.AhkBundle
+import de.nordgedanken.auto_hotkey.run_configurations.ui.AhkSdkListCellRenderer
+import de.nordgedanken.auto_hotkey.sdk.AhkSdkType
+import de.nordgedanken.auto_hotkey.sdk.getAhkSdks
+import de.nordgedanken.auto_hotkey.sdk.sdk
+import de.nordgedanken.auto_hotkey.util.NotificationUtil
+import java.io.File
+import javax.swing.JPanel
+import javax.swing.ListSelectionModel
+
+/**
+ * Constructs the UI and logic for the Ahk Sdk toolbar widget within the AutoHotkey settings that allows you to add or
+ * remove Sdks. This widget is necessary for non-IDEA IDEs, since they don't have a "Project Structure" dialog that
+ * you can use to manage Sdks.
+ */
+class AhkSdkToolbarPanel(project: Project) : JPanel() {
+    val panel: JPanel
+    private val availableSdksList: JBList<Sdk>
+    private val sdkListCellRenderer = AhkSdkListCellRenderer(project.sdk)
+    private val sdkListModel: CollectionListModel<Sdk> = CollectionListModel()
+
+    init {
+        sdkListModel.addAll(0, getAhkSdks())
+        availableSdksList = JBList<Sdk>(sdkListModel).apply {
+            emptyText.text = AhkBundle.msg("settings.ahkrunners.general.nosdks")
+            cellRenderer = sdkListCellRenderer
+            selectionMode = ListSelectionModel.SINGLE_SELECTION
+        }
+        panel = ToolbarDecorator.createDecorator(availableSdksList).apply {
+            setAddActionName(AhkBundle.msg("settings.ahkrunners.add.buttonlabel"))
+            setAddAction {
+                val ahkSdkType = AhkSdkType.getInstance()
+                val fileChooser = ahkSdkType.homeChooserDescriptor
+                FileChooser.chooseFile(fileChooser, null,
+                        LocalFileSystem.getInstance().findFileByIoFile(File(ahkSdkType.suggestHomePath()))) {
+                    chosenVirtualFile ->
+                    val existingSdk = sdkListModel.items.find { chosenVirtualFile.path == it.homePath }
+                    if (existingSdk != null) {
+                        NotificationUtil.showErrorDialog(project, AhkBundle.msg("settings.ahkrunners.add.error.exists.title"), AhkBundle.msg("settings.ahkrunners.add.error.exists.info").format(existingSdk.name))
+                    } else {
+                        val newlyAddedSdk = SdkConfigurationUtil.createAndAddSDK(chosenVirtualFile.path, AhkSdkType.getInstance())
+                        sdkListModel.add(newlyAddedSdk)
+                        availableSdksList.selectedIndex = sdkListModel.getElementIndex(newlyAddedSdk)
+                    }
+                }
+            }
+            setRemoveActionName(AhkBundle.msg("settings.ahkrunners.remove.buttonlabel"))
+            setRemoveAction {
+                val selectedIndex = availableSdksList.selectedIndex
+                val selectedSdk = availableSdksList.selectedValue
+                SdkConfigurationUtil.removeSdk(selectedSdk)
+                sdkListModel.remove(selectedSdk)
+                if(sdkListModel.size > 0) availableSdksList.selectedIndex = selectedIndex.coerceIn(0, sdkListModel.size - 1)
+            }
+            disableUpDownActions()
+        }.createPanel()
+    }
+}

--- a/src/main/java/de/nordgedanken/auto_hotkey/settings/ui/AhkSdkToolbarPanel.kt
+++ b/src/main/java/de/nordgedanken/auto_hotkey/settings/ui/AhkSdkToolbarPanel.kt
@@ -2,19 +2,24 @@ package de.nordgedanken.auto_hotkey.settings.ui
 
 import com.intellij.openapi.fileChooser.FileChooser
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.ProjectJdkTable
 import com.intellij.openapi.projectRoots.Sdk
 import com.intellij.openapi.projectRoots.impl.SdkConfigurationUtil
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.ui.CollectionListModel
+import com.intellij.ui.DoubleClickListener
 import com.intellij.ui.ToolbarDecorator
 import com.intellij.ui.components.JBList
+import com.jetbrains.rd.util.remove
 import de.nordgedanken.auto_hotkey.localization.AhkBundle
 import de.nordgedanken.auto_hotkey.run_configurations.ui.AhkSdkListCellRenderer
 import de.nordgedanken.auto_hotkey.sdk.AhkSdkType
 import de.nordgedanken.auto_hotkey.sdk.getAhkSdks
 import de.nordgedanken.auto_hotkey.sdk.sdk
 import de.nordgedanken.auto_hotkey.util.NotificationUtil
+import java.awt.event.MouseEvent
 import java.io.File
+import javax.swing.JOptionPane
 import javax.swing.JPanel
 import javax.swing.ListSelectionModel
 
@@ -23,7 +28,7 @@ import javax.swing.ListSelectionModel
  * remove Sdks. This widget is necessary for non-IDEA IDEs, since they don't have a "Project Structure" dialog that
  * you can use to manage Sdks.
  */
-class AhkSdkToolbarPanel(project: Project) : JPanel() {
+class AhkSdkToolbarPanel(val project: Project) : JPanel() {
     val panel: JPanel
     private val availableSdksList: JBList<Sdk>
     private val sdkListCellRenderer = AhkSdkListCellRenderer(project.sdk)
@@ -32,21 +37,21 @@ class AhkSdkToolbarPanel(project: Project) : JPanel() {
     init {
         sdkListModel.addAll(0, getAhkSdks())
         availableSdksList = JBList<Sdk>(sdkListModel).apply {
-            emptyText.text = AhkBundle.msg("settings.ahkrunners.general.nosdks")
+            emptyText.text = AhkBundle.msg("settings.autohotkey.ahkrunners.general.nosdks")
             cellRenderer = sdkListCellRenderer
             selectionMode = ListSelectionModel.SINGLE_SELECTION
+            createDoubleClickListener().installOn(this)
         }
         panel = ToolbarDecorator.createDecorator(availableSdksList).apply {
-            setAddActionName(AhkBundle.msg("settings.ahkrunners.add.buttonlabel"))
+            setAddActionName(AhkBundle.msg("settings.autohotkey.ahkrunners.add.buttonlabel"))
             setAddAction {
                 val ahkSdkType = AhkSdkType.getInstance()
                 val fileChooser = ahkSdkType.homeChooserDescriptor
                 FileChooser.chooseFile(fileChooser, null,
-                        LocalFileSystem.getInstance().findFileByIoFile(File(ahkSdkType.suggestHomePath()))) {
-                    chosenVirtualFile ->
+                        LocalFileSystem.getInstance().findFileByIoFile(File(ahkSdkType.suggestHomePath()))) { chosenVirtualFile ->
                     val existingSdk = sdkListModel.items.find { chosenVirtualFile.path == it.homePath }
                     if (existingSdk != null) {
-                        NotificationUtil.showErrorDialog(project, AhkBundle.msg("settings.ahkrunners.add.error.exists.title"), AhkBundle.msg("settings.ahkrunners.add.error.exists.info").format(existingSdk.name))
+                        NotificationUtil.showErrorDialog(project, AhkBundle.msg("settings.autohotkey.ahkrunners.add.error.exists.title"), AhkBundle.msg("settings.autohotkey.ahkrunners.add.error.exists.info").format(existingSdk.name))
                     } else {
                         val newlyAddedSdk = SdkConfigurationUtil.createAndAddSDK(chosenVirtualFile.path, AhkSdkType.getInstance())
                         sdkListModel.add(newlyAddedSdk)
@@ -54,7 +59,7 @@ class AhkSdkToolbarPanel(project: Project) : JPanel() {
                     }
                 }
             }
-            setRemoveActionName(AhkBundle.msg("settings.ahkrunners.remove.buttonlabel"))
+            setRemoveActionName(AhkBundle.msg("settings.autohotkey.ahkrunners.remove.buttonlabel"))
             setRemoveAction {
                 val selectedIndex = availableSdksList.selectedIndex
                 val selectedSdk = availableSdksList.selectedValue
@@ -62,7 +67,35 @@ class AhkSdkToolbarPanel(project: Project) : JPanel() {
                 sdkListModel.remove(selectedSdk)
                 if(sdkListModel.size > 0) availableSdksList.selectedIndex = selectedIndex.coerceIn(0, sdkListModel.size - 1)
             }
+            setEditActionName(AhkBundle.msg("settings.autohotkey.ahkrunners.edit.buttonlabel"))
+            setEditAction { editAction() }
             disableUpDownActions()
         }.createPanel()
     }
+
+    private fun editAction() {
+        val selectedSdk = availableSdksList.selectedValue
+        val newSdkName = JOptionPane.showInputDialog(AhkBundle.msg("settings.autohotkey.ahkrunners.edit.message").format(selectedSdk.name), selectedSdk.name) ?: selectedSdk.name
+        if (doesGivenNewNameExist(selectedSdk, newSdkName)) {
+            NotificationUtil.showErrorDialog(project, AhkBundle.msg("settings.autohotkey.ahkrunners.edit.error.alreadyexists.dialogtitle"), AhkBundle.msg("settings.autohotkey.ahkrunners.edit.error.alreadyexists.dialogmsg").format(newSdkName))
+        } else {
+            selectedSdk.sdkModificator.run {
+                name = newSdkName
+                commitChanges()
+            }
+        }
+    }
+
+    private fun doesGivenNewNameExist(sdkToRename: Sdk, newSdkName: String): Boolean {
+        val allSdks = ProjectJdkTable.getInstance().allJdks.remove(sdkToRename)
+        return allSdks.map { it.name }.contains(newSdkName)
+    }
+
+    private fun createDoubleClickListener() =
+            object : DoubleClickListener() {
+                override fun onDoubleClick(e: MouseEvent): Boolean {
+                    editAction()
+                    return true
+                }
+            }
 }

--- a/src/main/java/de/nordgedanken/auto_hotkey/util/NotificationUtil.java
+++ b/src/main/java/de/nordgedanken/auto_hotkey/util/NotificationUtil.java
@@ -1,4 +1,4 @@
-package de.nordgedanken.auto_hotkey.run_configurations.core;
+package de.nordgedanken.auto_hotkey.util;
 
 import com.intellij.execution.ExecutionManager;
 import com.intellij.execution.runners.ExecutionEnvironment;
@@ -16,7 +16,11 @@ public class NotificationUtil {
 		if(toolWindowManager.canShowNotification(toolWindowId)) {
 			toolWindowManager.notifyByBalloon(toolWindowId, MessageType.ERROR, message, AllIcons.General.Error, null);
 		} else {
-			Messages.showErrorDialog(project, UIUtil.toHtml(message), title);
+			showErrorDialog(project, title, message);
 		}
+	}
+
+	public static void showErrorDialog(Project project, String title, String message) {
+		Messages.showErrorDialog(project, UIUtil.toHtml(message), title);
 	}
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,11 @@
     <extensions defaultExtensionNs="com.intellij">
         <fileType name="AHK script" implementationClass="de.nordgedanken.auto_hotkey.AHKFileType"
                   fieldName="INSTANCE" language="AutoHotKey" extensions="ahk"/>
+        <projectConfigurable id="language.autohotkey"
+                             parentId="language"
+                             displayName="AutoHotkey"
+                             instance="de.nordgedanken.auto_hotkey.settings.AhkProjectConfigurable"/>
+
         <sdkType implementation="de.nordgedanken.auto_hotkey.sdk.AhkSdkType"/>
         <configurationType implementation="de.nordgedanken.auto_hotkey.run_configurations.core.AhkRunConfigType"/>
 

--- a/src/main/resources/localization/AhkBundle.properties
+++ b/src/main/resources/localization/AhkBundle.properties
@@ -10,7 +10,7 @@ runconfig.configtab.scriptrunner.label=Script &Runner:
 runconfig.configtab.scriptrunner.sdklabel.default=Project Default
 runconfig.configtab.scriptrunner.sdklabel.unrecognized=Unrecognized SDK
 runconfig.configtab.scriptrunner.sdklabel.noneselected=No AutoHotkey SDK found
-runconfig.configtab.scriptrunner.projectsettingsbutton.tooltip=Click here to open the Project Structure dialog where you can add a new AutoHotkey SDK
+runconfig.configtab.scriptrunner.projectsettingsbutton.tooltip=Configure AutoHotkey Runners
 
 runconfig.configtab.error.scriptpath.notexist=The script path does not exist on disk!
 runconfig.configtab.error.scriptpath.notahkextension=The script path does not point to an AutoHotkey (.ahk) file!
@@ -19,3 +19,11 @@ runconfig.configtab.error.scriptrunner.notahksdktype=The script runner does not 
 runconfig.general.info.label=Note: It is recommended to create/use a shortcut to rerun the config (eg Ctrl+Alt+R) during development for quick script reloading
 
 ahksdktype.invalidhome=AutoHotkey.exe could not be found in the selected folder. Please ensure that AutoHotkey.exe is within the folder that you are selecting
+
+settings.ahkrunners.general.label=AutoHotkey runners:
+settings.ahkrunners.general.info=NOTE: Any runners added or deleted above are saved immediately, regardless of whether you press "OK" or "Cancel" in the Settings window
+settings.ahkrunners.general.nosdks=No AutoHotkey runners have been added
+settings.ahkrunners.add.buttonlabel=Add a new AutoHotkey Runner
+settings.ahkrunners.add.error.exists.title=Runner already exists!
+settings.ahkrunners.add.error.exists.info=An AutoHotkey runner with this path already exists: %s
+settings.ahkrunners.remove.buttonlabel=Remove an AutoHotkey Runner

--- a/src/main/resources/localization/AhkBundle.properties
+++ b/src/main/resources/localization/AhkBundle.properties
@@ -20,10 +20,14 @@ runconfig.general.info.label=Note: It is recommended to create/use a shortcut to
 
 ahksdktype.invalidhome=AutoHotkey.exe could not be found in the selected folder. Please ensure that AutoHotkey.exe is within the folder that you are selecting
 
-settings.ahkrunners.general.label=AutoHotkey runners:
-settings.ahkrunners.general.info=NOTE: Any runners added or deleted above are saved immediately, regardless of whether you press "OK" or "Cancel" in the Settings window
-settings.ahkrunners.general.nosdks=No AutoHotkey runners have been added
-settings.ahkrunners.add.buttonlabel=Add a new AutoHotkey Runner
-settings.ahkrunners.add.error.exists.title=Runner already exists!
-settings.ahkrunners.add.error.exists.info=An AutoHotkey runner with this path already exists: %s
-settings.ahkrunners.remove.buttonlabel=Remove an AutoHotkey Runner
+settings.autohotkey.ahkrunners.general.label=AutoHotkey runners:
+settings.autohotkey.ahkrunners.general.info=NOTE: Any runners added or deleted above are saved immediately, regardless of whether you press "OK" or "Cancel" in the Settings window
+settings.autohotkey.ahkrunners.general.nosdks=No AutoHotkey runners have been added
+settings.autohotkey.ahkrunners.add.buttonlabel=Add a new AutoHotkey Runner
+settings.autohotkey.ahkrunners.add.error.exists.title=Runner already exists!
+settings.autohotkey.ahkrunners.add.error.exists.info=An AutoHotkey runner with this path already exists: %s
+settings.autohotkey.ahkrunners.remove.buttonlabel=Remove an AutoHotkey Runner
+settings.autohotkey.ahkrunners.edit.buttonlabel=Edit Runner Name
+settings.autohotkey.ahkrunners.edit.message=Please enter a new name for runner "%s":
+settings.autohotkey.ahkrunners.edit.error.alreadyexists.dialogtitle=Runner Name Already Exists!
+settings.autohotkey.ahkrunners.edit.error.alreadyexists.dialogmsg=The runner name you provided, "%s", already exists! Please choose a unique name.


### PR DESCRIPTION
Took forever to figure out, but now we should be able to manage the Ahk sdks inside Settings dialog so we don't need to use Project Structure. Screenshot below shows the plugin working in PyCharm:

![image](https://user-images.githubusercontent.com/6986426/90312613-e0405680-ded3-11ea-9020-77ab708c8dc3.png)

We can probably cut a release version from this to see if jetbrains marketplace accepts the plugin after this PR