### PR TITLE
#37: Add "print errors to console" option within the run config ui

### DIFF
--- a/.github/workflows/build_plugin.yml
+++ b/.github/workflows/build_plugin.yml
@@ -54,6 +54,9 @@ jobs:
     - name: Run Tests
       run: ./gradlew test
 
+    # Verify code coverage
+    - name: Run Tests
+      run: ./gradlew checkTestCoverage
 
   # Build plugin with buildPlugin Gradle task and provide the artifact for the next workflow jobs
   # Requires test job to be passed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New option "Print errors to console" in run config
+
 ### Changed
 - Modified syntax-highlighting to just comments. Commented other code to prevent errors.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,9 +29,13 @@ dependencies {
     implementation("com.google.flogger:flogger:0.5.1")
     implementation("com.google.flogger:flogger-system-backend:0.5.1")
 
-    testImplementation("org.junit.jupiter:junit-jupiter:5.7.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.0")
-    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.7.0")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:4.4.0")
+    testImplementation("io.kotest:kotest-assertions-core:4.4.0")
+    testImplementation("io.kotest:kotest-property:4.4.0")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.7.0") {
+        because("this is needed to run parsing/lexing tests which extend " +
+                "intellij base classes that use junit4")
+    }
 }
 
 val intellijPublishToken: String? by project

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
     id("org.jetbrains.grammarkit") version "2020.1.4"
     kotlin("jvm") version "1.3.72"
     java
+    jacoco
+    id("org.barfuin.gradle.jacocolog") version "1.2.4" //show coverage in console
 }
 
 group = "de.nordgedanken"
@@ -119,3 +121,52 @@ tasks.withType<KotlinCompile> {
         freeCompilerArgs = listOf("-Xjvm-default=enable")
     }
 }
+
+val packagesToExcludeFromCoverageCheck = listOf(
+    //below runconfig directories require more complex tests
+    "**/auto_hotkey/runconfig/core/**",
+    "**/auto_hotkey/runconfig/execution/**",
+
+    //swing ui packages; must be tested manually
+    "**/auto_hotkey/runconfig/ui/**",
+    "**/auto_hotkey/settings/ui/**"
+)
+
+tasks.jacocoTestReport {
+    classDirectories.setFrom(
+        files(classDirectories.files.map {
+            fileTree(it) {
+                exclude(packagesToExcludeFromCoverageCheck)
+            }
+        })
+    )
+}
+
+tasks.jacocoTestCoverageVerification {
+    classDirectories.setFrom(
+        sourceSets.main.get().output.asFileTree.matching {
+            exclude(packagesToExcludeFromCoverageCheck)
+        }
+    )
+
+    violationRules {
+        rule {
+            limit {
+                counter = "LINE"
+                minimum = "0.60".toBigDecimal()
+            }
+        }
+    }
+}
+
+tasks.register("checkTestCoverage") {
+    group = "verification"
+    description = "Runs the unit tests with coverage."
+
+    dependsOn(":test", ":jacocoTestReport", ":jacocoTestCoverageVerification")
+    val jacocoTestReport = tasks.jacocoTestReport.get()
+    jacocoTestReport.mustRunAfter(tasks.test)
+    tasks.jacocoTestCoverageVerification.get().mustRunAfter(jacocoTestReport)
+}
+
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/de/nordgedanken/auto_hotkey/lang/parser/AhkParserDefinition.kt
+++ b/src/main/java/de/nordgedanken/auto_hotkey/lang/parser/AhkParserDefinition.kt
@@ -13,8 +13,9 @@ import com.intellij.psi.tree.TokenSet
 import de.nordgedanken.auto_hotkey.lang.core.AhkLanguage
 import de.nordgedanken.auto_hotkey.lang.lexer.AhkLexerAdapter
 import de.nordgedanken.auto_hotkey.lang.psi.AhkFile
-import de.nordgedanken.auto_hotkey.lang.psi.AhkTypes.*
-import de.nordgedanken.auto_hotkey.lang.psi.*
+import de.nordgedanken.auto_hotkey.lang.psi.AhkTypes.Factory
+import de.nordgedanken.auto_hotkey.lang.psi.COMMENT_TOKENS
+import de.nordgedanken.auto_hotkey.lang.psi.WHITESPACE_TOKENS
 
 class AhkParserDefinition : ParserDefinition {
     override fun createLexer(project: Project?): Lexer = AhkLexerAdapter()
@@ -31,7 +32,7 @@ class AhkParserDefinition : ParserDefinition {
 
     override fun createFile(viewProvider: FileViewProvider): PsiFile = AhkFile(viewProvider)
 
-    override fun spaceExistanceTypeBetweenTokens(left: ASTNode, right: ASTNode) = ParserDefinition.SpaceRequirements.MAY
+    override fun spaceExistenceTypeBetweenTokens(left: ASTNode, right: ASTNode) = ParserDefinition.SpaceRequirements.MAY
 
     override fun createElement(node: ASTNode?): PsiElement =
             Factory.createElement(node)

--- a/src/main/java/de/nordgedanken/auto_hotkey/runconfig/core/AhkRunConfig.kt
+++ b/src/main/java/de/nordgedanken/auto_hotkey/runconfig/core/AhkRunConfig.kt
@@ -57,7 +57,7 @@ class AhkRunConfig(
      */
     override fun readExternal(element: Element) {
         super.readExternal(element)
-        runConfigSettings.populateFromElement(element)
+        runConfigSettings.readFromElement(element)
     }
 
     /**

--- a/src/main/java/de/nordgedanken/auto_hotkey/runconfig/execution/AhkRunState.kt
+++ b/src/main/java/de/nordgedanken/auto_hotkey/runconfig/execution/AhkRunState.kt
@@ -20,6 +20,7 @@ class AhkRunState(private val ahkRunConfig: AhkRunConfig, environment: Execution
         val ahkCommandLine = GeneralCommandLine()
                 .withWorkDirectory(ahkRunConfig.project.basePath)
                 .withExePath(exePath)
+                .withParameters(ahkRunConfig.runConfigSettings.getEnabledSwitchesAsList())
                 .withParameters(ahkRunConfig.runConfigSettings.pathToScript)
                 .withParameters(ahkRunConfig.runConfigSettings.getArgsAsList())
         return KillableProcessHandler(ahkCommandLine)

--- a/src/main/java/de/nordgedanken/auto_hotkey/runconfig/model/AhkSwitch.kt
+++ b/src/main/java/de/nordgedanken/auto_hotkey/runconfig/model/AhkSwitch.kt
@@ -1,0 +1,25 @@
+package de.nordgedanken.auto_hotkey.runconfig.model
+
+/**
+ * Contains a list of valid command-line flags that you can provide to
+ * AutoHotkey.exe while executing a script.
+ *
+ * See https://www.autohotkey.com/docs/Scripts.htm#cmd
+ */
+enum class AhkSwitch(val switchName: String) {
+    ERROR_STD_OUT("/ErrorStdOut"),
+    ;
+
+    companion object {
+        fun isValidSwitch(switchNameToCheck: String): Boolean {
+            return enumValues<AhkSwitch>().any { it.switchName == switchNameToCheck }
+        }
+
+        /**
+         * Throws an exception if the passed-in switch name is not valid
+         */
+        fun valueOfBySwitchName(switchName: String): AhkSwitch {
+            return values().first { it.switchName == switchName }
+        }
+    }
+}

--- a/src/main/java/de/nordgedanken/auto_hotkey/util/AhkBundle.java
+++ b/src/main/java/de/nordgedanken/auto_hotkey/util/AhkBundle.java
@@ -1,6 +1,6 @@
 package de.nordgedanken.auto_hotkey.util;
 
-import com.intellij.CommonBundle;
+import com.intellij.AbstractBundle;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.PropertyKey;
 
@@ -22,6 +22,6 @@ public class AhkBundle {
 	 * Ex: AhkBundle.msg("runconfig.configtab.scriptpath.label")
 	 */
 	public static String msg(@PropertyKey(resourceBundle = BUNDLE_NAME) String key, Object... params) {
-		return CommonBundle.message(BUNDLE, key, params);
+		return AbstractBundle.message(BUNDLE, key, params);
 	}
 }

--- a/src/main/java/de/nordgedanken/auto_hotkey/util/NotificationUtil.java
+++ b/src/main/java/de/nordgedanken/auto_hotkey/util/NotificationUtil.java
@@ -1,7 +1,7 @@
 package de.nordgedanken.auto_hotkey.util;
 
-import com.intellij.execution.ExecutionManager;
 import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.ui.RunContentManager;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.MessageType;
@@ -11,7 +11,7 @@ import com.intellij.util.ui.UIUtil;
 
 public class NotificationUtil {
 	public static void showErrorPopup(final String title, final String message, final Project project, final ExecutionEnvironment environment) {
-		String toolWindowId = ExecutionManager.getInstance(project).getContentManager().getToolWindowIdByEnvironment(environment);
+		String toolWindowId = RunContentManager.getInstance(project).getToolWindowIdByEnvironment(environment);
 		ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(project);
 		if(toolWindowManager.canShowNotification(toolWindowId)) {
 			toolWindowManager.notifyByBalloon(toolWindowId, MessageType.ERROR, message, AllIcons.General.Error, null);

--- a/src/main/resources/localization/AhkBundle.properties
+++ b/src/main/resources/localization/AhkBundle.properties
@@ -11,6 +11,8 @@ runconfig.configtab.scriptrunner.sdklabel.default=Project Default
 runconfig.configtab.scriptrunner.sdklabel.unrecognized=Unrecognized runner
 runconfig.configtab.scriptrunner.sdklabel.noneselected=No AutoHotkey runners found
 runconfig.configtab.scriptrunner.projectsettingsbutton.tooltip=Configure AutoHotkey Runners
+runconfig.configtab.switches.errorstdout.label=Print errors to console
+runconfig.configtab.switches.errorstdout.tooltip=If this option is unchecked, errors will be shown in a dialog box instead
 
 runconfig.configtab.error.scriptpath.notexist=The script path does not exist on disk!
 runconfig.configtab.error.scriptpath.notahkextension=The script path does not point to an AutoHotkey (.ahk) file!

--- a/src/test/java/de/nordgedanken/auto_hotkey/runconfig/model/AhkRunConfigSettingsTest.kt
+++ b/src/test/java/de/nordgedanken/auto_hotkey/runconfig/model/AhkRunConfigSettingsTest.kt
@@ -1,13 +1,86 @@
 package de.nordgedanken.auto_hotkey.runconfig.model
 
-import org.junit.jupiter.api.Assertions.assertArrayEquals
-import org.junit.jupiter.api.Test
+import io.kotest.core.datatest.forAll
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.jdom.Element
+import org.jdom.input.SAXBuilder
+import org.jdom.output.Format
+import org.jdom.output.XMLOutputter
+import util.TestUtil.readResourceToString
+import java.io.StringReader
 
-internal class AhkRunConfigSettingsTest {
+class AhkRunConfigSettingsTest : FunSpec({
+    context("verify custom getters") {
+        context("getEnabledSwitchesAsList") {
+            forAll<Pair<AhkRunConfigSettings, List<String>>>(
+                "default" to Pair(AhkRunConfigSettings(), listOf("/ErrorStdOut")),
+                "empty switch list" to Pair(
+                    AhkRunConfigSettings(switches = mutableMapOf()),
+                    emptyList()
+                ),
+                "one enabled switch" to Pair(
+                    AhkRunConfigSettings(switches = mutableMapOf(AhkSwitch.ERROR_STD_OUT to true)),
+                    listOf("/ErrorStdOut")
+                ),
+                "one disabled switch" to Pair(
+                    AhkRunConfigSettings(switches = mutableMapOf(AhkSwitch.ERROR_STD_OUT to false)),
+                    emptyList()
+                )
+            ) { (settings, expectedList) ->
+                settings.getEnabledSwitchesAsList() shouldContainExactly expectedList
+            }
+        }
 
-    @Test
-    fun getArgsAsList() {
-        val runConfigSettings = AhkRunConfigSettings(arguments = "arg1 \"arg2 extended\"")
-        assertArrayEquals(arrayOf("arg1", "arg2 extended"), runConfigSettings.getArgsAsList().toTypedArray())
+        context("getArgsAsList") {
+            forAll<Pair<AhkRunConfigSettings, List<String>>>(
+                "default" to Pair(AhkRunConfigSettings(), emptyList()),
+                "regular args" to Pair(
+                    AhkRunConfigSettings(arguments = """arg1 arg2"""),
+                    listOf("arg1", "arg2")
+                ),
+                "quoted args" to Pair(
+                    AhkRunConfigSettings(arguments = """arg1 "ar g2" arg3"""),
+                    listOf("arg1", "ar g2", "arg3")
+                )
+            ) { (settings, expectedList) ->
+                settings.getArgsAsList() shouldContainExactly expectedList
+            }
+        }
     }
-}
+
+    context("test xml operations") {
+        test("test read from xml") {
+            val actualXml = readResourceToString("runconfig/model/samplerunconfigsettings.xml")
+            val actualElement = SAXBuilder().build(StringReader(actualXml)).rootElement
+            println(actualElement.getChild("switches").getChild("switch").attributes)
+            val actualSettings = AhkRunConfigSettings().apply {
+                readFromElement(actualElement)
+            }
+            print(actualSettings)
+
+            val expectedSettings = AhkRunConfigSettings(
+                runner = "AutoHotkey",
+                pathToScript = """C:\my\test\path""",
+                arguments = "test1 test2"
+            )
+            actualSettings shouldBe expectedSettings
+        }
+
+        test("test write to xml") {
+            val testSettings = AhkRunConfigSettings(
+                runner = "AutoHotkey",
+                pathToScript = """C:\my\test\path""",
+                arguments = "test1 test2"
+            )
+            val actualElement = Element("configuration")
+            testSettings.writeToElement(actualElement)
+
+            val expectedXml = readResourceToString("runconfig/model/samplerunconfigsettings.xml")
+            val expectedElement = SAXBuilder().build(StringReader(expectedXml)).rootElement
+            XMLOutputter(Format.getCompactFormat()).outputString(actualElement)
+                .shouldBe(XMLOutputter(Format.getCompactFormat()).outputString(expectedElement))
+        }
+    }
+})

--- a/src/test/java/util/TestUtil.kt
+++ b/src/test/java/util/TestUtil.kt
@@ -1,0 +1,9 @@
+package util
+
+const val PACKAGE_PREFIX = "/de/nordgedanken/auto_hotkey"
+
+object TestUtil {
+    fun readResourceToString(path: String): String {
+        return javaClass.getResource("$PACKAGE_PREFIX/$path").readText()
+    }
+}

--- a/src/test/resources/de/nordgedanken/auto_hotkey/runconfig/model/samplerunconfigsettings.xml
+++ b/src/test/resources/de/nordgedanken/auto_hotkey/runconfig/model/samplerunconfigsettings.xml
@@ -1,0 +1,8 @@
+<configuration>
+	<option name="runner" value="AutoHotkey"/>
+	<option name="pathToScript" value="C:\my\test\path"/>
+	<option name="arguments" value="test1 test2"/>
+	<switches>
+		<switch name="/ErrorStdOut" enabled="true"/>
+	</switches>
+</configuration>


### PR DESCRIPTION
Spent some time over the last 2 weeks and finally got a checkbox working to print errors to console:
<img src="https://user-images.githubusercontent.com/6986426/107867805-e8aa2780-6e4b-11eb-93b5-f9de67ed1fd0.png" data-canonical-src="https://user-images.githubusercontent.com/6986426/107867805-e8aa2780-6e4b-11eb-93b5-f9de67ed1fd0.png" width="600" />

I also integrated jacoco into the build script so now we can generate code coverage reports. (I added a bunch of tests and a new coverage check in the github workflow to verify that the coverage is correct.)

(I know you're still thinking about a new maintainer in #38; if you haven't made a decision on that yet, you can publish v0.4.0 with this PR merged)
